### PR TITLE
Add ABAP sales order list program

### DIFF
--- a/list_sales_orders.abap
+++ b/list_sales_orders.abap
@@ -1,0 +1,13 @@
+REPORT zlist_sales_orders.
+
+*----------------------------------------------------------------------
+* Display list of sales orders
+*----------------------------------------------------------------------
+TABLES: vbak.
+
+SELECT * FROM vbak INTO TABLE @DATA(lt_vbak) UP TO 100 ROWS.
+
+LOOP AT lt_vbak INTO DATA(ls_vbak).
+  WRITE: / ls_vbak-vbeln, ls_vbak-auart, ls_vbak-erdat, ls_vbak-kunnr.
+ENDLOOP.
+


### PR DESCRIPTION
## Summary
- add sample ABAP report to display SAP sales orders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404ff152e0832e8f28d31f48955f9e